### PR TITLE
Changes for version 0.5.4 (dependency updates)

### DIFF
--- a/.project
+++ b/.project
@@ -5,8 +5,20 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
 	<filteredResources>
 		<filter>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.5] - 2024-02-29
+
+### Changed in 0.5.5
+
+- Updated dependency versions:
+  - Updated `senzing-commons-java` to version `3.2.0`
+  - Updated Amazon AWS dependencies from version `2.22.12` to `2.24.12`
+  - Updated `junit-jupiter` from version `5.10.1` to `5.10.2`
+  - Updated `postgresql` from version `42.7.1` to `42.7.2`
+  - Updated `maven-surefire-plugin` from version `3.2.3` to `3.2.5`
+
 ## [0.5.4] - 2024-01-10
 
 ### Changed in 0.5.4

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.4</version>
+  <version>0.5.5</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.22.12</version>
+        <version>2.24.12</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.1.5, 3.999.999]</version>
+      <version>[3.2.0, 3.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -94,77 +94,77 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.22.12</version>
+      <version>2.24.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.1</version>
+      <version>5.10.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.1</version>
+      <version>42.7.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.3</version>
+        <version>3.2.5</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>


### PR DESCRIPTION
- Updated dependency versions:
  - Updated `senzing-commons-java` to version `3.2.0`
  - Updated Amazon AWS dependencies from version `2.22.12` to `2.24.12`
  - Updated `junit-jupiter` from version `5.10.1` to `5.10.2`
  - Updated `postgresql` from version `42.7.1` to `42.7.2`
  - Updated `maven-surefire-plugin` from version `3.2.3` to `3.2.5`
