### PR TITLE
Added support for PostgreSQL v13.x (version 0.5.6 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2024-03-20
+
+### Changed in 0.5.6
+
+- Added support for PostgreSQL v13.x by changing changing `CREATE OR REPLACE TRIGGER`
+  to `DROP TRIGGER` and `CREATE TRIGGER`
+
 ## [0.5.5] - 2024-02-29
 
 ### Changed in 0.5.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-listener-builder" \
       Maintainer="support@senzing.com" \
-      Version="0.5.5"
+      Version="0.5.6"
 
 # Set environment variables.
 
@@ -39,7 +39,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-listener" \
       Maintainer="support@senzing.com" \
-      Version="0.5.5"
+      Version="0.5.6"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.5</version>
+  <version>0.5.6</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>

--- a/src/main/java/com/senzing/listener/service/scheduling/PostgreSQLSchedulingService.java
+++ b/src/main/java/com/senzing/listener/service/scheduling/PostgreSQLSchedulingService.java
@@ -1,10 +1,6 @@
 package com.senzing.listener.service.scheduling;
 
 import java.sql.*;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import static com.senzing.sql.SQLUtilities.close;
@@ -81,7 +77,7 @@ public class PostgreSQLSchedulingService extends AbstractSQLSchedulingService {
             + "$$;";
 
     String createTriggerSql =
-        "CREATE OR REPLACE TRIGGER sz_follow_up_tasks_trigger "
+        "CREATE TRIGGER sz_follow_up_tasks_trigger "
             + "  BEFORE INSERT OR UPDATE "
             + "  ON sz_follow_up_tasks "
             + "  FOR EACH ROW "
@@ -108,6 +104,7 @@ public class PostgreSQLSchedulingService extends AbstractSQLSchedulingService {
     sqlList.add(createIndexSql1);
     sqlList.add(createIndexSql2);
     sqlList.add(createTriggerFunctionSql);
+    sqlList.add(dropTriggerSql);
     sqlList.add(createTriggerSql);
 
     // execute the statements


### PR DESCRIPTION
Added support for PostgreSQL v13.x by changing changing `CREATE OR REPLACE TRIGGER` to `DROP TRIGGER` and `CREATE TRIGGER`.