### PR TITLE
Fixed PostgreSQL v13.x support for version 0.5.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2024-03-20
+
+### Changed in 0.5.6
+
+- Added support for PostgreSQL v13.x by changing changing `CREATE OR REPLACE TRIGGER`
+  to `DROP TRIGGER` and `CREATE TRIGGER`
+
 ## [0.5.5] - 2024-02-29
 
 ### Changed in 0.5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2024-03-21
+
+### Changed in 0.5.7
+
+- Fixed bug in PostgreSQL v13.x support for `com.senzing.listener.communication.sql.PostgreSQLClient`
+- Fixed bug in `com.senzing.listener.service.scheduling.PostgreSQLSchedulingService` prevnting the
+  trigger from being dropped properly.
+
 ## [0.5.6] - 2024-03-20
 
 ### Changed in 0.5.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in PostgreSQL v13.x support for `com.senzing.listener.communication.sql.PostgreSQLClient`
 - Fixed bug in `com.senzing.listener.service.scheduling.PostgreSQLSchedulingService` prevnting the
   trigger from being dropped properly.
+- Updated `commons-configuration2` dependency from version `2.9.0` to version `2.10.1`
 
 ## [0.5.6] - 2024-03-20
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-listener-builder" \
       Maintainer="support@senzing.com" \
-      Version="0.5.6"
+      Version="0.5.7"
 
 # Set environment variables.
 
@@ -39,7 +39,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-listener" \
       Maintainer="support@senzing.com" \
-      Version="0.5.6"
+      Version="0.5.7"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-listener-builder" \
       Maintainer="support@senzing.com" \
-      Version="0.5.5"
+      Version="0.5.6"
 
 # Set environment variables.
 
@@ -39,7 +39,7 @@ ENV REFRESHED_AT=2024-03-18
 
 LABEL Name="senzing/senzing-listener" \
       Maintainer="support@senzing.com" \
-      Version="0.5.5"
+      Version="0.5.6"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.5</version>
+  <version>0.5.6</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.9.0</version>
+      <version>2.10.1</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.6</version>
+  <version>0.5.7</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>

--- a/src/main/java/com/senzing/listener/communication/sql/PostgreSQLClient.java
+++ b/src/main/java/com/senzing/listener/communication/sql/PostgreSQLClient.java
@@ -80,7 +80,7 @@ public class PostgreSQLClient implements SQLClient {
                 + "$$;";
     
         String createTriggerSql =
-            "CREATE OR REPLACE TRIGGER sz_msg_queue_trigger "
+            "CREATE TRIGGER sz_msg_queue_trigger "
                 + "  BEFORE INSERT OR UPDATE "
                 + "  ON sz_message_queue "
                 + "  FOR EACH ROW "
@@ -106,6 +106,7 @@ public class PostgreSQLClient implements SQLClient {
         sqlList.add(createTableSql);
         sqlList.add(createIndexSql);
         sqlList.add(createTriggerFunctionSql);
+        sqlList.add(dropTriggerSql);
         sqlList.add(createTriggerSql);
       
         // execute the statements

--- a/src/main/java/com/senzing/listener/service/scheduling/PostgreSQLSchedulingService.java
+++ b/src/main/java/com/senzing/listener/service/scheduling/PostgreSQLSchedulingService.java
@@ -1,10 +1,6 @@
 package com.senzing.listener.service.scheduling;
 
 import java.sql.*;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 import static com.senzing.sql.SQLUtilities.close;
@@ -81,7 +77,7 @@ public class PostgreSQLSchedulingService extends AbstractSQLSchedulingService {
             + "$$;";
 
     String createTriggerSql =
-        "CREATE OR REPLACE TRIGGER sz_follow_up_tasks_trigger "
+        "CREATE TRIGGER sz_follow_up_tasks_trigger "
             + "  BEFORE INSERT OR UPDATE "
             + "  ON sz_follow_up_tasks "
             + "  FOR EACH ROW "
@@ -108,6 +104,7 @@ public class PostgreSQLSchedulingService extends AbstractSQLSchedulingService {
     sqlList.add(createIndexSql1);
     sqlList.add(createIndexSql2);
     sqlList.add(createTriggerFunctionSql);
+    sqlList.add(dropTriggerSql);
     sqlList.add(createTriggerSql);
 
     // execute the statements

--- a/src/main/java/com/senzing/listener/service/scheduling/PostgreSQLSchedulingService.java
+++ b/src/main/java/com/senzing/listener/service/scheduling/PostgreSQLSchedulingService.java
@@ -89,7 +89,7 @@ public class PostgreSQLSchedulingService extends AbstractSQLSchedulingService {
 
     String dropTriggerSql =
         "DROP TRIGGER IF EXISTS sz_follow_up_tasks_trigger "
-            + "ON sz_follow_up_timestamps;";
+            + "ON sz_follow_up_tasks;";
 
     List<String> sqlList = new ArrayList<>();
 


### PR DESCRIPTION
- Fixed bug in PostgreSQL v13.x support for `com.senzing.listener.communication.sql.PostgreSQLClient`
- 
- Fixed bug in `com.senzing.listener.service.scheduling.PostgreSQLSchedulingService` prevnting the trigger from being dropped properly.

- Updated `commons-configuration2` dependency from version `2.9.0` to version `2.10.1`
