### PR TITLE
Updated dependencies and CHANGELOG for version 0.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed in 0.5.9
 
-- Updasted `senzing-commons-java` dependency from version `3.2.0` to version `3.3.0`
+- Updated `senzing-commons-java` dependency from version `3.2.0` to version `3.3.0`
 - Updated Amazon AWS dependencies to version `2.26.4`
 - Updated `commons-configuration2` dependency from version `2.10.1` to version `2.11.0`
 - Updated `amqp-client` dependency from version `5.20.0` to version `5.21.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.9] - 2024-06-20
+
+### Changed in 0.5.9
+
+- Updasted `senzing-commons-java` dependency from version `3.2.0` to version `3.3.0`
+- Updated Amazon AWS dependencies to version `2.26.4`
+- Updated `commons-configuration2` dependency from version `2.10.1` to version `2.11.0`
+- Updated `amqp-client` dependency from version `5.20.0` to version `5.21.0`
+- Updated `commons-cli` dependency from version `1.6.0` to version `1.8.0`
+- Updated `postgresql` dependency from version `42.7.2` to version `42.7.3`
+- Updated `maven-compiler-plugin` dependency from version `3.12.1` to version `3.13.0`
+- Updated `maven-surefire-plugin` dependency from version `3.2.5` to version `3.3.0`
+- Updated `maven-source-plugin` dependency from version `3.3.0` to version `3.3.1`
+- Updated `maven-javadoc-plugin` dependency from version `3.6.3` to version `3.7.0`
+- Updated `maven-gpg-plugin` dependency from version `3.1.0` to version `3.2.4`
+- Updated `nexus-staging-maven-plugin` dependency from version `1.6.13` to version `1.7.0`
+
 ## [0.5.8] - 2024-05-22
 
 ### Changed in 0.5.8

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.7</version>
+  <version>0.5.9</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.24.12</version>
+        <version>2.26.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -79,92 +79,92 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.2.0, 3.999.999]</version>
+      <version>[3.3.0, 3.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.10.1</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.20.0</version>
+      <version>5.21.0</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.25.21</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.25.0</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.25.0</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.25.0</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.24.12</version>
+      <version>2.26.4</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
-      <version>1.6.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.7.2</version>
+      <version>42.7.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -209,7 +209,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.12.1</version>
+        <version>3.13.0</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:unchecked</arg>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.2.5</version>
+        <version>3.3.0</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -239,7 +239,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.7.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -265,7 +265,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.4</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -279,7 +279,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.13</version>
+        <version>1.7.0</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>


### PR DESCRIPTION
- Updated `senzing-commons-java` dependency from version `3.2.0` to version `3.3.0`
- Updated Amazon AWS dependencies to version `2.26.4`
- Updated `commons-configuration2` dependency from version `2.10.1` to version `2.11.0`
- Updated `amqp-client` dependency from version `5.20.0` to version `5.21.0`
- Updated `commons-cli` dependency from version `1.6.0` to version `1.8.0`
- Updated `postgresql` dependency from version `42.7.2` to version `42.7.3`
- Updated `maven-compiler-plugin` dependency from version `3.12.1` to version `3.13.0`
- Updated `maven-surefire-plugin` dependency from version `3.2.5` to version `3.3.0`
- Updated `maven-source-plugin` dependency from version `3.3.0` to version `3.3.1`
- Updated `maven-javadoc-plugin` dependency from version `3.6.3` to version `3.7.0`
- Updated `maven-gpg-plugin` dependency from version `3.1.0` to version `3.2.4`
- Updated `nexus-staging-maven-plugin` dependency from version `1.6.13` to version `1.7.0`
