### PR TITLE
Updated dependencies and promoted to version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2024-08-02
+
+### Changed in 1.0.0
+
+- Promoted to version `1.0.0` release
+- In `pom.xml`:
+  - Updated Amazon AWS dependencies from version `2.26.4` to `2.26.27`
+  - Updated `junit-jupiter` from version `5.10.2` to version `5.10.3`
+  - Updated `maven-surefire-plugin` from version `3.3.0` to `3.3.31`
+  - Updated `maven-javadoc-plugin` from version `3.7.0` to `3.8.0`
+
 ## [0.5.10] - 2024-06-24
 
 ### Changed in 0.5.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV REFRESHED_AT=2024-06-24
 
 LABEL Name="senzing/senzing-listener" \
   Maintainer="support@senzing.com" \
-  Version="0.5.10"
+  Version="1.0.0"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.9</version>
+  <version>1.0.0</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.26.4</version>
+        <version>2.26.27</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -94,77 +94,77 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.26.4</version>
+      <version>2.26.27</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.2</version>
+      <version>5.10.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
- Promoted to version `1.0.0` release
- In `pom.xml`:
  - Updated Amazon AWS dependencies from version `2.26.4` to `2.26.27`
  - Updated `junit-jupiter` from version `5.10.2` to version `5.10.3`
  - Updated `maven-surefire-plugin` from version `3.3.0` to `3.3.31`
  - Updated `maven-javadoc-plugin` from version `3.7.0` to `3.8.0`
