### PR TITLE
Updated dependencies for version 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2024-12-05
+
+### Changed in 1.0.2
+
+- Updated dependencies:
+  - Updated `senzing-commons` from version `3.3.1` to `3.3.2`
+  - Updated `amqp-client` from version `5.22.0` to `5.23.0`
+  - Updated Amazon AWS dependencies from version `2.28.17` to `2.29.26`
+  - Updated `junit-jupiter` from version `5.11.2` to version `5.11.3`
+  - Updated `maven-surefire-plugin` from version `3.5.1` to `3.5.2`
+  - Updated `maven-javadoc-plugin` from version `3.10.1` to `3.11.1`
+
 ## [1.0.1] - 2024-10-08
 
 ### Changed in 1.0.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ENV REFRESHED_AT=2024-06-24
 
 LABEL Name="senzing/senzing-listener" \
   Maintainer="support@senzing.com" \
-  Version="1.0.0"
+  Version="1.0.2"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/senzing-garage/senzing-listener</url>
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.28.17</version>
+        <version>2.29.26</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.3.1, 3.999.999]</version>
+      <version>[3.3.2, 3.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -89,82 +89,82 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.22.0</version>
+      <version>5.23.0</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.28.17</version>
+      <version>2.29.26</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.11.2</version>
+      <version>5.11.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.1</version>
+        <version>3.5.2</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.10.1</version>
+        <version>3.11.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
- Updated dependencies in version 1.0.2:
  - Updated `senzing-commons` from version `3.3.1` to `3.3.2`
  - Updated `amqp-client` from version `5.22.0` to `5.23.0`
  - Updated Amazon AWS dependencies from version `2.28.17` to `2.29.26`
  - Updated `junit-jupiter` from version `5.11.2` to version `5.11.3`
  - Updated `maven-surefire-plugin` from version `3.5.1` to `3.5.2`
  - Updated `maven-javadoc-plugin` from version `3.10.1` to `3.11.1`